### PR TITLE
NP-False-Positive: Ignored false positive message

### DIFF
--- a/alert-filters.json
+++ b/alert-filters.json
@@ -7,6 +7,14 @@
       "ruleId": 10021,
       "urlIsRegex": "true",
       "newLevel": 0
+    },
+    {
+      "reason": "Information Disclosure - Debug Error Messages",
+      "contextId": 1,
+      "url": "http://localhost:9070/authorisations",
+      "ruleId": 10023,
+      "urlIsRegex": "true",
+      "newLevel": -1
     }
   ]
 }


### PR DESCRIPTION
Our API returns structured error on 5xx, so the ZAP alert is a false positive