### PR TITLE
NP-328: Changed error message for 503 to match what API platform return

### DIFF
--- a/src/test/scala/uk/gov/hmrc/api/models/constants/ApiErrorCodes.scala
+++ b/src/test/scala/uk/gov/hmrc/api/models/constants/ApiErrorCodes.scala
@@ -25,6 +25,6 @@ object ApiErrorCodes {
   val methodNotAllowed: String         = "METHOD_NOT_ALLOWED"
   val notAcceptable: String            = "NOT_ACCEPTABLE"
   val requestEntityTooLarge: String    = "REQUEST_ENTITY_TOO_LARGE"
-  val serviceUnavailable: String       = "SERVICE_UNAVAILABLE"
+  val serviceUnavailable: String       = "SERVER_ERROR"
   val unauthorized: String             = "UNAUTHORIZED"
 }

--- a/src/test/scala/uk/gov/hmrc/api/models/constants/ApiErrorMessages.scala
+++ b/src/test/scala/uk/gov/hmrc/api/models/constants/ApiErrorMessages.scala
@@ -30,6 +30,6 @@ object ApiErrorMessages {
   val notAcceptable: String            =
     "Cannot produce an acceptable response. The Accept or Content-Type header is missing or invalid"
   val requestEntityTooLarge: String    = "Request Entity Too Large"
-  val serviceUnavailable: String       = "Server is currently unable to handle the incoming requests"
+  val serviceUnavailable: String       = "Service Unavailable"
   val unauthorized: String             = "The bearer token is invalid, missing, or expired"
 }


### PR DESCRIPTION
- Api platform discard our message on 503 and return their own, so we must change our code and message to match theirs